### PR TITLE
Added Acrylic and Reveal system colors to the generated markup

### DIFF
--- a/FluentEditor/ControlPalette/Model/ControlPaletteExportProvider.cs
+++ b/FluentEditor/ControlPalette/Model/ControlPaletteExportProvider.cs
@@ -49,6 +49,15 @@ namespace FluentEditor.ControlPalette.Model
             }
             sb.AppendLine(" />");
             sb.AppendLine("            <ResourceDictionary>");
+
+            Windows.UI.Color ChromeAltMediumHigh = model.DarkRegion.ActiveColor;
+            ChromeAltMediumHigh.A = 204;
+
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemChromeAltMediumHighColor\">{0}</Color>", ChromeAltMediumHigh.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemChromeAltHighColor\">{0}</Color>", model.DarkRegion.ActiveColor.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemRevealListLowColor\">{0}</Color>", model.DarkBase.Palette[8].ActiveColor.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemRevealListMediumColor\">{0}</Color>", model.DarkBase.Palette[5].ActiveColor.ToString()));
+
             sb.AppendLine(string.Format("                <Color x:Key=\"RegionColor\">{0}</Color>", model.DarkRegion.ActiveColor.ToString()));
             sb.AppendLine("                <SolidColorBrush x:Key=\"RegionBrush\" Color=\"{StaticResource RegionColor}\" />");
             if (showAllColors)
@@ -121,6 +130,15 @@ namespace FluentEditor.ControlPalette.Model
             }
             sb.AppendLine(" />");
             sb.AppendLine("            <ResourceDictionary>");
+
+            ChromeAltMediumHigh = model.LightRegion.ActiveColor;
+            ChromeAltMediumHigh.A = 204;
+
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemChromeAltMediumHighColor\">{0}</Color>", ChromeAltMediumHigh.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemChromeAltHighColor\">{0}</Color>", model.LightRegion.ActiveColor.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemRevealListLowColor\">{0}</Color>", model.LightBase.Palette[1].ActiveColor.ToString()));
+            sb.AppendLine(string.Format("                <Color x:Key=\"SystemRevealListMediumColor\">{0}</Color>", model.LightBase.Palette[5].ActiveColor.ToString()));
+
             sb.AppendLine(string.Format("                <Color x:Key=\"RegionColor\">{0}</Color>", model.LightRegion.ActiveColor.ToString()));
             sb.AppendLine("                <SolidColorBrush x:Key=\"RegionBrush\" Color=\"{StaticResource RegionColor}\" />");
             if (showAllColors)


### PR DESCRIPTION
As title suggests. Added the Acrylic system colors necessary to tint the system acrylic brushes. I also added in Reveal's list hover colors because in investigating this I noticed that they were missing.